### PR TITLE
v1.1.3 - last minute addition - apply .trim() to all cells

### DIFF
--- a/src/jira_markup.gs
+++ b/src/jira_markup.gs
@@ -63,10 +63,11 @@ function jiraMarkup(input_sheet_name, output_sheet_name) {
   for (i = 0; i < rows; i++) {
     if (i != 0) {
       /* EC: read all values as strings to fix the issue when a number is only entered in a cell */
-      step   = values[i][0].toString();
-      desc   = values[i][1].toString();
-      expect = values[i][2].toString();
-      notes  = values[i][3].toString();
+      /* trim gets rid of leading and trailing whitespaces */
+      step   = values[i][0].toString().trim();
+      desc   = values[i][1].toString().trim();
+      expect = values[i][2].toString().trim();
+      notes  = values[i][3].toString().trim();
 
       /* replace all tabs with spaces
        * helps prevent the quotation marks showing up after copying


### PR DESCRIPTION
before when a User would paste a Jira Table that was generated by JTT, there would be increasingly more trailing and leading whitespaces. 

now .trim() makes sure that no trailing nor leading whitespaces get into the Spreadsheet output... however due to having to copy directly from the spreadsheet, there are always a small number of tabs in the end result. This is a minor issue that can be resolved by copying from a prompt instead (TODO)