### PR TITLE
Apply New design for Quote Implication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.4] - 2018-09-10
+## [1.1.4] - 2018-11-09
 ### Added
+- added functionality for including "quote" into the step name column to create a quote in the previous row. 
 - added a copy button that puts the whole output into a popup dialog - [#12]. Thanks [@phelpstylerb]!
 
 ## [1.1.3] - 2018-08-19
@@ -47,12 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0] - 2018-05-18
 First version.
 
-[Unreleased]: https://github.com/mfekadu/JiraTestTool/compare/v1.0.0...
-[1.1.4]: https://github.com/mfekadu/JiraTestTool/compare/v1.1.0...v1.1.4
-[1.1.3]: https://github.com/mfekadu/JiraTestTool/compare/v1.1.0...v1.1.3
-[1.1.2]: https://github.com/mfekadu/JiraTestTool/compare/v1.1.0...v1.1.2
-[1.1.1]: https://github.com/mfekadu/JiraTestTool/compare/v1.1.0...v1.1.1
-[1.1.0]: https://github.com/mfekadu/JiraTestTool/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/mfekadu/JiraTestTool/releases/tag/v1.0.0
+[Unreleased]: https://github.com/JiraTestTool/JiraTestTool/compare/v1.0.0...
+[1.1.4]: https://github.com/JiraTestTool/JiraTestTool/compare/v1.1.0...v1.1.4
+[1.1.3]: https://github.com/JiraTestTool/JiraTestTool/compare/v1.1.0...v1.1.3
+[1.1.2]: https://github.com/JiraTestTool/JiraTestTool/compare/v1.1.0...v1.1.2
+[1.1.1]: https://github.com/JiraTestTool/JiraTestTool/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/JiraTestTool/JiraTestTool/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/JiraTestTool/JiraTestTool/releases/tag/v1.0.0
 [#12]: https://github.com/JiraTestTool/JiraTestTool/pull/12
 [@phelpstylerb]: https://github.com/phelpstylerb

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Requires 3 sheets (Input/Output/Keywords) as in [this Google Sheet template][tem
 A project for Tapestry Solutions in SLO.
 
 Contributors:
-Michael Fekadu, Jonathan Devera, Chris Toh, Eric Cole
+Michael Fekadu, Jonathan Devera, Chris Toh, Eric Cole, Tyler Phelps
 
 
 

--- a/src/helpers_jira_markup.gs
+++ b/src/helpers_jira_markup.gs
@@ -176,9 +176,7 @@ function textFormatting(text, b_list, i_list, u_list){
     }
   }
 
-  /* the single-quote at the front tells Google Sheets to
-   * parse cell as plain-text rather than formula */
-  return "'" + splitArray.join(" ");
+  return splitArray.join(" ");
 }
 
 


### PR DESCRIPTION
simplified the code for text clean up onto 1 line

moved the "single-quote" addition code into jiraMarkup() rather than textFormatting() because the content of `desc` and other variable is now more readable and explicit

out_values.length is the number of rows as opposed to the number of iterations